### PR TITLE
:desktop_computer: Learn Combinational Logic, case/casez, and Priority Constructs with Simple HDL Modules

### DIFF
--- a/CS/CO/DDCA/04-HDL/17-comb-inv.vhd
+++ b/CS/CO/DDCA/04-HDL/17-comb-inv.vhd
@@ -15,4 +15,7 @@ begin
   process(all) begin
     y <= not a;
   end process;
+
+  -- In a VHDL 'process' statement, ':=' indicates a blocking assignment and <=
+  -- indicates a non-blocking assignment.
 end;

--- a/CS/CO/DDCA/04-HDL/18-fulladder.sv
+++ b/CS/CO/DDCA/04-HDL/18-fulladder.sv
@@ -1,0 +1,53 @@
+module fulladder (
+  input  logic a, b, cin,
+  output logic s, cout
+);
+  logic p, g;
+
+  always_comb
+    begin
+      p = a ^ b;
+      g = a & b;
+      s = p ^ cin;
+      cout = g | (p & cin);
+    end
+
+  // In this case, 'always @(a, b, cin)' would have been equivalent to 'always_comb'.
+  // However 'always_comb' is better because it avoids common mistakes of missing
+  // signals in the sensitivity list.
+  //
+  // It's best to use blocking assignments for combination logic.
+
+  //                  cin
+  //                   ↓
+  //      +-------------------------+
+  //  a → | a ^ b ^ cin             | → s
+  //  b → | a & b | ((a ^ b) & cin) | → cout
+  //      +-------------------------+
+  //
+  //    a    b    cin    |    s    cout
+  //    0    0     0     |    0      0
+  //    0    0     1     |    1      0
+  //    0    1     0     |    1      0
+  //    0    1     1     |    0      1
+  //    1    0     0     |    1      0
+  //    1    0     1     |    0      1
+  //    1    1     0     |    0      1
+  //    1    1     1     |    1      1
+
+  //    s = a ^ b ^ cin
+  //    +-> s is only 1 when odd numbers of them are 1, and that's xor
+  // cout = (a & b) | (a & cin) | (b & cin)
+  //      = (a & b) | ((a | b) & cin)
+  //    +-> Actually when a and b are both 1, a & b is 1 so we can reuse a ^ b
+  //    +-> instead of a | b.
+  //    +->
+  //    +-> +--------+--------+--------+--------+--------+
+  //    +-> | cin\ab |   00   |   01   |   11   |   10   |
+  //    +-> +--------+--------+--------+--------+--------+
+  //    +-> |   0    |   0    |   0    |   1    |   0    |
+  //    +-> +--------+--------+--------+--------+--------+
+  //    +-> |   1    |   0    |   1    |   1    |   1    |
+  //    +-> +--------+--------+--------+--------+--------+
+
+endmodule

--- a/CS/CO/DDCA/04-HDL/18-fulladder.vhd
+++ b/CS/CO/DDCA/04-HDL/18-fulladder.vhd
@@ -1,0 +1,28 @@
+library IEEE; use IEEE.STD_LOGIC_1164.all;
+
+entity fulladder is
+  port(
+    a, b, cin: in  STD_LOGIC;
+    s, cout:   out STD_LOGIC
+  );
+end;
+
+architecture synth of fulladder is
+begin
+  process(all)
+    variable p, g: STD_LOGIC;
+  begin
+    p := a xor b;
+    g := a and b;
+    s <= p xor cin;
+    cout <= g or (p and cin);
+  end process;
+
+  -- In this case, 'process(a, b, cin)' would have been equivalent to 'process(
+  -- all)'. However, 'process(all)' is better because it avoids common mistakes
+  -- of missing signals in the sensitivity list.
+  --
+  -- This example uses blocking assignments for 'p' and 'g' so that they get
+  -- their new values before being used to compute 's' and 'cout' that depend on
+  -- them. And they must be declared as 'variable' rather than 'signal'.
+end;

--- a/CS/CO/DDCA/04-HDL/19-seven-segments.sv
+++ b/CS/CO/DDCA/04-HDL/19-seven-segments.sv
@@ -1,0 +1,33 @@
+module seven_segments(
+  input  logic [3:0] data,
+  output logic [6:0] segments
+);
+
+  //       a
+  //    +----+
+  // f  |  g | b
+  //    +----+
+  // e  |    | c
+  //    +----+
+  //       d
+
+  always_comb
+    case (data)
+      //                     abc_defg
+      0:       segments = 7'b111_1110;
+      1:       segments = 7'b011_0000;
+      2:       segments = 7'b110_1101;
+      3:       segments = 7'b111_1001;
+      4:       segments = 7'b011_0011;
+      5:       segments = 7'b101_1010;
+      6:       segments = 7'b111_0000;
+      8:       segments = 7'b111_1111;
+      9:       segments = 7'b111_1011;
+      default: segments = 7'b000_0000;
+    endcase
+
+    // The case statement checks the value of data. When data is <value>, then
+    // the statement performs the <statement> after the given <value> branch.
+    // In SystemVerilog, case statement must appear in always block.
+
+endmodule

--- a/CS/CO/DDCA/04-HDL/19-seven-segments.vhd
+++ b/CS/CO/DDCA/04-HDL/19-seven-segments.vhd
@@ -3,7 +3,7 @@ library IEEE; use IEEE.STD_LOGIC_1164.all;
 entity seven_segments_decoder is
   port(
     data:     in  STD_LOGIC_VECTOR(3 downto 0);
-    segments: out STD_LOGIC_VECTOR(7 downto 0)
+    segments: out STD_LOGIC_VECTOR(6 downto 0)
   );
 end;
 

--- a/CS/CO/DDCA/04-HDL/19-seven-segments.vhd
+++ b/CS/CO/DDCA/04-HDL/19-seven-segments.vhd
@@ -1,0 +1,36 @@
+library IEEE; use IEEE.STD_LOGIC_1164.all;
+
+entity seven_segments_decoder is
+  port(
+    data:     in  STD_LOGIC_VECTOR(3 downto 0);
+    segments: out STD_LOGIC_VECTOR(7 downto 0)
+  );
+end;
+
+--       a
+--    +----+
+-- f  |  g | b
+--    +----+
+-- e  |    | c
+--    +----+
+--       d
+
+architecture synth of seven_segments_decoder is
+begin
+  process(all) begin
+    case data is
+      --                          abcdefg
+      when X"0"   => segments <= "1111110";
+      when X"1"   => segments <= "0110000";
+      when X"2"   => segments <= "1101101";
+      when X"3"   => segments <= "1111001";
+      when X"4"   => segments <= "0110011";
+      when X"5"   => segments <= "1011011";
+      when X"6"   => segments <= "1011111";
+      when X"7"   => segments <= "1110000";
+      when X"8"   => segments <= "1111111";
+      when X"9"   => segments <= "1111011";
+      when others => segments <= "0000000";
+    end case;
+  end process;
+end;

--- a/CS/CO/DDCA/04-HDL/20-priority-ctk.sv
+++ b/CS/CO/DDCA/04-HDL/20-priority-ctk.sv
@@ -1,0 +1,13 @@
+module priority_ctk(
+  input  logic [3:0] a,
+  output logic [3:0] y
+);
+
+  always_comb
+    if      (a[3]) y = 4'b1000;
+    else if (a[2]) y = 4'b0100;
+    else if (a[1]) y = 4'b0010;
+    else if (a[0]) y = 4'b0001;
+    else           y = 4'b0000;
+
+endmodule

--- a/CS/CO/DDCA/04-HDL/20-priority-ctk.vhd
+++ b/CS/CO/DDCA/04-HDL/20-priority-ctk.vhd
@@ -1,0 +1,25 @@
+library IEEE; use IEEE.STD_LOGIC_1164.all;
+
+entity priority_ctk is
+  port(
+    a: in  STD_LOGIC_VECTOR(3 downto 0);
+    y: out STD_LOGIC_VECTOR(3 downto 0)
+  );
+end;
+
+architecture synth of priority_ctk is
+begin
+  process(all) begin
+    if    a(3) then y <= "1000";
+    elsif a(2) then y <= "0100";
+    elsif a(1) then y <= "0010";
+    elsif a(0) then y <= "0001";
+    else            y <= "0000";
+    end if;
+
+    -- Unlike SystemVerilog, VHDL supports conditional signal assignment
+    -- statements, which are much like 'if' statements but can appear outside
+    -- processes. Thus, there is less reason to use processes to describe
+    -- combinational logic.
+  end process;
+end;

--- a/CS/CO/DDCA/04-HDL/21-priority-casez.sv
+++ b/CS/CO/DDCA/04-HDL/21-priority-casez.sv
@@ -1,0 +1,18 @@
+module priority_casez (
+  input  logic [3:0] a,
+  output logic [3:0] y
+);
+
+  always_comb
+    casez (a)
+        4'b1???: y = 4'b1000;
+        4'b01??: y = 4'b0100;
+        4'b001?: y = 4'b0010;
+        4'b0001: y = 4'b0001;
+        default: y = 4'b0000;
+    endcase
+
+    // The 'casez' statement acts like a 'case' statement except that it also
+    // recognizes ? as don't care.
+
+endmodule

--- a/CS/CO/DDCA/04-HDL/21-priority-casez.vhd
+++ b/CS/CO/DDCA/04-HDL/21-priority-casez.vhd
@@ -1,0 +1,24 @@
+library IEEE; use IEEE.STD_LOGIC_1164.all;
+
+entity priority_casez is
+  port(
+    a: in  STD_LOGIC_VECTOR(3 downto 0);
+    y: out STD_LOGIC_VECTOR(3 downto 0)
+  );
+end;
+
+architecture dontcare of priority_casez is
+begin
+  process(all) begin
+    case? a is
+      when "1---" => y <= "1000";
+      when "01--" => y <= "0100";
+      when "001-" => y <= "0010";
+      when "0001" => y <= "0001";
+      when others => y <= "0000";
+    end case?;
+
+    -- The 'case?' statement acts like a 'case' statement except that it also
+    -- recognizes - as don't care.
+  end process;
+end;


### PR DESCRIPTION
This PR continues my **DDCA (Digital Design & Computer Architecture)** learning journey by exploring **combinational logic description styles** and **conditional selection constructs** in HDL.
The focus is on understanding how different control structures (`if/else`, `case`, `casez`, priority logic) affect **readability, intent, and synthesis behavior**.

All changes are part of a personal learning repository aimed at building intuition for hardware description from first principles.

## 📚 Learning Goals

* Understand multiple ways to describe combinational logic
* Compare `if/else` vs `case` vs `casez` semantics
* Learn priority encoding behavior in HDL
* Reinforce correct usage of blocking assignments in combinational logic
* Practice small, concrete circuit examples instead of abstract theory

## 🔧 Implemented / Updated Modules

1. Full Adder & Blocking Assignments (09a8c6f7)

* Implemented a basic full adder
* Used **blocking assignments (`=`)** to model combinational behavior
* Key takeaways:

  * Why blocking assignments are preferred in combinational logic
  * Clear data flow and evaluation order
  * Avoiding unintended latches

2. Seven-Segment Decoder using `case` (a1195530)

* Implemented a seven-segment display decoder
* Used a `case` statement for clean value-to-pattern mapping
* Key takeaways:

  * `case` improves readability over chained `if/else`
  * Explicit coverage of all input patterns
  * Importance of `default` branches

3. Priority Logic using `if / else` in Always / Process Blocks (62cadab8)

* Implemented priority selection logic
* Demonstrated how `if / else if` naturally infers priority
* Key takeaways:

  * Implicit priority in conditional chains
  * How synthesis tools interpret priority logic
  * When priority is intentional vs accidental

4. Priority Matching with `casez` (3099108e)

* Used `casez` to ignore lower-order bits
* Demonstrated **don’t-care (`z`) matching**
* Key takeaways:

  * Difference between `case`, `casez`, and `casex`
  * Expressing priority without long `if/else` chains
  * Cleaner intent for pattern-based decoding

## 💡 Key Concepts Reinforced

* Combinational logic modeling in HDL
* Blocking vs non-blocking assignments
* Priority inference in synthesis
* Pattern matching and don’t-care conditions
* Writing intent-clear, synthesis-friendly HDL

## 🧠 Why This Matters

These small examples mirror **real design decisions** in larger systems:

* Decoder logic
* Control signal selection
* Instruction decoding
* Priority arbitration

By experimenting with multiple styles, this PR helps build intuition about **how HDL code maps to hardware**, not just how to make simulations pass.

## Summary by Sourcery

Add small HDL examples to explore combinational logic description styles and priority encoding in both VHDL and SystemVerilog.

New Features:
- Introduce full adder modules in VHDL and SystemVerilog using blocking-style combinational logic.
- Add seven-segment display decoder modules in VHDL and SystemVerilog implemented with case-style selection.
- Add priority encoder modules in VHDL and SystemVerilog using if/else chains and casez-style don’t-care matching.

Enhancements:
- Clarify documentation comments on blocking vs non-blocking assignments and sensitivity lists in existing combinational logic examples.

Documentation:
- Embed explanatory comments in new and existing HDL modules to reinforce concepts like blocking assignments, case/casez behavior, and priority handling.